### PR TITLE
Replace panel-heading

### DIFF
--- a/OdeToFood/OdeToFood/Pages/Restaurants/_Summary.cshtml
+++ b/OdeToFood/OdeToFood/Pages/Restaurants/_Summary.cshtml
@@ -2,10 +2,8 @@
 @model Restaurant
 
 <div class="card">
-    <div class="panel-heading">
-        <h3>@Model.Name</h3>
-    </div>
     <div class="card-body">
+        <h3 class="card-title">@Model.Name</h3>
         <span>Location: @Model.Location</span>
         <span>Cuisine: @Model.Cuisine</span>
     </div>


### PR DESCRIPTION
panel-heading is no longer a bootstrap 4 class.

Utilizing card-title instead as it is the most common use case for cards in the Bootstrap 4 docs.